### PR TITLE
Setting Page Improvements.

### DIFF
--- a/admin/init.php
+++ b/admin/init.php
@@ -18,24 +18,35 @@ function pmproz_add_submenu_page() {
 
 function pmproz_admin_init() {
 
+	// check to see if the account_settings tab is being displayed.
+	if( isset( $_REQUEST[ 'account_settings' ] ) ) {
+		$account = $_REQUEST[ 'account_settings' ];
+	} else {
+		$account = false;
+	}
+
 	// Register setting.
 	register_setting( 'pmproz_options', 'pmproz_options', 'pmproz_options_validate' );
 
-	// Add sections.
-	add_settings_section( 'pmproz_settings_general', __( 'Account Settings', 'pmpro-zapier' ), 'pmproz_settings_general', 'pmproz_options' );
-	add_settings_section( 'pmproz_settings_triggers', __( 'Triggers', 'pmpro-zapier' ), 'pmproz_settings_triggers', 'pmproz_options' );
+	// Load settings for triggers.
+	if( ! $account ){
+		add_settings_section( 'pmproz_settings_triggers', __( 'Triggers', 'pmpro-zapier' ), 'pmproz_settings_triggers', 'pmproz_options' );
+		// Add trigger fields.
+		add_settings_field( 'pmproz_settings_field_pmpro_added_order', __( 'New Order', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_added_order', 'pmproz_options', 'pmproz_settings_triggers' );
+		add_settings_field( 'pmproz_settings_field_pmpro_added_order_url', __( 'New Order Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_added_order_url', 'pmproz_options', 'pmproz_settings_triggers' );
+		add_settings_field( 'pmproz_settings_field_pmpro_updated_order', __( 'Updated Order', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_updated_order', 'pmproz_options', 'pmproz_settings_triggers' );
+		add_settings_field( 'pmproz_settings_field_pmpro_updated_order_url', __( 'Updated Order Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_updated_order_url', 'pmproz_options', 'pmproz_settings_triggers' );
+		add_settings_field( 'pmproz_settings_field_pmpro_after_change_membership_level', __( 'Changed Membership Level', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_after_change_membership_level', 'pmproz_options', 'pmproz_settings_triggers' );
+		add_settings_field( 'pmproz_settings_field_pmpro_after_change_membership_level_url', __( 'Changed Membership Level Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_after_change_membership_level_url', 'pmproz_options', 'pmproz_settings_triggers' );
+	}
 
-	// Add general fields.
-	add_settings_field( 'pmproz_settings_field_api_key', __( 'API Key', 'pmpro-zapier' ), 'pmproz_settings_field_api_key', 'pmproz_options', 'pmproz_settings_general' );
-
-	// Add trigger fields.
-	add_settings_field( 'pmproz_settings_field_pmpro_added_order', __( 'New Order', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_added_order', 'pmproz_options', 'pmproz_settings_triggers' );
-	add_settings_field( 'pmproz_settings_field_pmpro_added_order_url', __( 'New Order Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_added_order_url', 'pmproz_options', 'pmproz_settings_triggers' );
-	add_settings_field( 'pmproz_settings_field_pmpro_updated_order', __( 'Updated Order', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_updated_order', 'pmproz_options', 'pmproz_settings_triggers' );
-	add_settings_field( 'pmproz_settings_field_pmpro_updated_order_url', __( 'Updated Order Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_updated_order_url', 'pmproz_options', 'pmproz_settings_triggers' );
-	add_settings_field( 'pmproz_settings_field_pmpro_after_change_membership_level', __( 'Changed Membership Level', 'pmproz' ), 'pmproz_settings_field_pmpro_after_change_membership_level', 'pmproz_options', 'pmproz_settings_triggers' );
-	add_settings_field( 'pmproz_settings_field_pmpro_after_change_membership_level_url', __( 'Changed Membership Level Webhook URL', 'pmpro-zapier' ), 'pmproz_settings_field_pmpro_after_change_membership_level_url', 'pmproz_options', 'pmproz_settings_triggers' );
-
+	// Load settings for account settings
+	if( $account ) {
+		// Add sections.
+		add_settings_section( 'pmproz_settings_general', __( 'Account Settings', 'pmpro-zapier' ), 'pmproz_settings_general', 'pmproz_options' );
+		// Add general fields.
+		add_settings_field( 'pmproz_settings_field_api_key', __( 'API Key', 'pmpro-zapier' ), 'pmproz_settings_field_api_key', 'pmproz_options', 'pmproz_settings_general' );
+	}
 }
 add_action( 'admin_init', 'pmproz_admin_init' );
 

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -6,8 +6,8 @@ $pmproz_options = get_option('pmproz_options');
 function pmproz_settings_general() {
 
 	global $pmproz_options;
-
 	?>
+
 	<p>
 		<?php _e( 'Enter these when connecting to a Paid Memberships Pro account in Zapier.', 'pmpro-zapier' ); ?>
 	</p>
@@ -20,11 +20,13 @@ function pmproz_settings_general() {
 			</td>
 		</tr>
 	</table>
+
 	<?php
 
 }
 
-function pmproz_settings_triggers() {}
+function pmproz_settings_triggers() {
+}
 
 function pmproz_settings_field_api_key() {
 
@@ -96,21 +98,35 @@ function pmproz_settings_field_pmpro_after_change_membership_level_url() {
 	$value = !empty( $pmproz_options[ 'pmpro_after_change_membership_level_url' ] ) ? $pmproz_options[ 'pmpro_after_change_membership_level_url' ] : '';
 	?>
 	<input  type="text" name="pmproz_options[pmpro_after_change_membership_level_url]" size=60 value="<?php echo $value; ?>">
-
-<?php }
-
-?>
+<?php } ?>
 
 <div class="wrap">
+	<?php settings_errors(); ?>
 	<form action="options.php" method="POST">
-		<h1><?php _e('Paid Memberships Pro Zapier', 'pmproz'); ?></h1>
-		<h3><?php _e('Easily integrate Paid Memberships Pro and hundreds of other apps with Zapier.', 'pmproz'); ?></h3>
+		<h1><?php _e( 'Paid Memberships Pro Zapier', 'pmpro-zapier' ); ?></h1>
+		<h3><?php _e( 'Easily integrate Paid Memberships Pro and hundreds of other apps with Zapier.', 'pmpro-zapier' ); ?></h3>
 		<p>
 			<?php echo __( 'Paid Memberships Pro  Zapier enables 2-way communication between Paid Memberships Pro and hundreds of other services using Zapier.
 			For more information, visit ', 'pmpro-zapier' ) . '<a href="https://zapier.com" target="_blank" rel="noopener">Zapier.com</a>'; ?>
 		</p>
+		<?php
+		if( isset( $_REQUEST[ 'account_settings' ] ) ) {
+			$account = $_REQUEST[ 'account_settings' ];
+		} else {
+			$account = false;
+		}
+		?>
+		<h2 class="nav-tab-wrapper">
+			<a href="admin.php?page=pmpro-zapier" class="nav-tab<?php if( empty( $account ) ) { ?> nav-tab-active<?php } ?>"><?php _e( 'Trigger Settings', 'pmpro-zapier' ); ?></a>
+			<a href="admin.php?page=pmpro-zapier&account_settings=1" class="nav-tab<?php if( ! empty( $account ) ) { ?> nav-tab-active<?php } ?>"><?php _e( 'Account Settings', 'pmpro-zapier' ); ?></a>
+		</h2>
+
 		<?php do_settings_sections( 'pmproz_options' ); ?>
 		<?php settings_fields( 'pmproz_options' ); ?>
-		<?php submit_button(); ?>
+		<?php 
+		if( ! $account ) {	
+			submit_button(); 
+		}
+		 ?>
 	</form>
 </div>

--- a/includes/webhook-handler.php
+++ b/includes/webhook-handler.php
@@ -21,7 +21,7 @@ header( 'Content-Type: application/json' );
 
 if ( $api_key != $pmproz_options['api_key'] ) {
 	status_header( 403 );
-	echo json_encode( __( 'A valid API key is required.', 'pmproz' ) );
+	echo json_encode( __( 'A valid API key is required.', 'pmpro-zapier' ) );
 	exit;
 }
 
@@ -53,7 +53,7 @@ switch ( $action ) {
 
 		// failed to get the user object.
 		if( empty( $user ) ){
-			$pmpro_error .= 'You must pass in a user_id, user_login, or user_email. ';
+			$pmpro_error .= 'You must pass in a user_id, user_login, or user_email.';
 		}
 		
 		//check the level


### PR DESCRIPTION
Implemented tabbed settings.

Implemented wrapped text with correct text-domain

Removed 'Save Settings' button for account settings page, since this simply is read-only fields. (Settings for Zapier to webhook, PMPro.)