### PR TITLE
if cancelling a level, we set level->id instead of level->ID like we …

### DIFF
--- a/includes/class-pmpro-zapier.php
+++ b/includes/class-pmpro-zapier.php
@@ -147,7 +147,7 @@ class PMPro_Zapier {
 		// Cancelling
 		if ( $level_id == 0 ) {
 			$level     = new StdClass();
-			$level->id = '0';
+			$level->ID = '0';
 		} else {
 			$level = pmpro_getMembershipLevelForUser( $user_id );
 


### PR DESCRIPTION
…do when changing level. Fixes issue #40.