### PR TITLE
API Key Generated on Save Bug Fixed

### DIFF
--- a/includes/class-pmpro-zapier.php
+++ b/includes/class-pmpro-zapier.php
@@ -39,8 +39,14 @@ class PMPro_Zapier {
 	static function get_options() {
 		$options = get_option( 'pmproz_options' );
 
+		if( !empty( $_REQUEST['pmproz_generate_api_key'] ) && current_user_can( 'manage_options' ) ){
+			$can_generate = true;
+		} else {
+			$can_generate = false;
+		}
+
 		// generate an API key if we don't have one yet
-		if ( empty( $options['api_key'] ) ) {
+		if ( empty( $options['api_key'] ) || $can_generate ) {
 			$options['api_key'] = wp_generate_password( 32, false );
 			PMPro_Zapier::update_options( $options );
 		}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -94,9 +94,9 @@ add_action( 'admin_init', 'pmproz_admin_init' );
  * Validate PMPro Zapier settings/options
  */
 function pmproz_options_validate( $input ) {
-
+	$options = get_option( 'pmproz_options' );
 	$new_input                                        = array();
-	$new_input['api_key']                             = ! empty( $input['api_key'] ) ? sanitize_key( $input['api_key'] ) : '';
+	$new_input['api_key']                             = ! empty( $input['api_key'] ) ? sanitize_key( $input['api_key'] ) : $options['api_key'];
 	$new_input['pmpro_added_order']                   = ! empty( $input['pmpro_added_order'] ) ? intval( $input['pmpro_added_order'] ) : '';
 	$new_input['pmpro_updated_order']                 = ! empty( $input['pmpro_updated_order'] ) ? intval( $input['pmpro_updated_order'] ) : '';
 	$new_input['pmpro_after_change_membership_level'] = ! empty( $input['pmpro_after_change_membership_level'] ) ? intval( $input['pmpro_after_change_membership_level'] ) : '';
@@ -193,9 +193,12 @@ function pmproz_settings_triggers() {
  */
 function pmproz_settings_field_api_key() {
 	$pmproz_options = PMPro_Zapier::get_options();
+
 	?>
 	<input type="text" name="pmproz_options[api_key]" size=40 value="<?php echo esc_attr( $pmproz_options['api_key'] ); ?>" readonly>
 	<?php
+
+	
 }
 
 /**


### PR DESCRIPTION
- The API key would get regenerated every time you hit Save (now fixed)
- You can generate a new API key by visiting the Zapier Settings page and run /?pmproz_generate_api_key=true in the URL to generate a new one (admins only)