### PR TITLE
Adding MMPU compatibility

### DIFF
--- a/includes/class-pmpro-zapier.php
+++ b/includes/class-pmpro-zapier.php
@@ -153,8 +153,7 @@ class PMPro_Zapier {
 			$level     = new StdClass();
 			$level->ID = '0';
 		} else {
-			$level = pmpro_getMembershipLevelForUser( $user_id );
-
+			$level = clone pmpro_getSpecificMembershipLevelForUser( $user_id, $level_id ); // Clone since we're going to modify the level object.
 			// Unset some unnecessary things.
 			unset( $level->allow_signups );
 			unset( $level->categories );
@@ -179,8 +178,12 @@ class PMPro_Zapier {
 		$data['user_email'] = $user->user_email;
 		
 		// Get old level's status so we know why they changed levels.
-		$sqlQuery                 = "SELECT status FROM {$wpdb->pmpro_memberships_users} WHERE user_id = {$user_id} AND status NOT LIKE 'active' ORDER BY id DESC LIMIT 1";
-		$data['old_level_status'] = $wpdb->get_var( $sqlQuery );
+		if ( ! empty( $cancel_level ) ) {
+			$data['old_level_status'] = $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$wpdb->pmpro_memberships_users} WHERE user_id = %d AND membership_id = %d AND status NOT LIKE 'active' ORDER BY id LIMIT 1", $user_id, $cancel_level ) );
+		}
+		if ( empty( $data['old_level_status'] ) ) {
+			$data['old_level_status'] = '';
+		}
 
 		$data['level'] = $level;
 
@@ -212,7 +215,7 @@ class PMPro_Zapier {
 		$data['username']   = $user->user_login;
 		$data['user_email'] = $user->user_email;
 
-		$level = pmpro_getMembershipLevelForUser( $user_id );
+		$level = clone pmpro_getSpecificMembershipLevelForUser( $user_id, $order->membership_id ); // Clone since we're going to modify the level object.
 		if ( ! empty( $level ) ) {
 			$data['level_id'] = $level->id;
 			$data['level_name'] = $level->name;

--- a/includes/webhook-handler.php
+++ b/includes/webhook-handler.php
@@ -91,11 +91,11 @@ switch ( $action ) {
 			$user_id = $user->ID;
 		}
 
-		// make sure we have a user and he or she doesn't have a membership level already
+		// make sure we have a user and he or she doesn't have the membership level already
 		if ( empty( $user_id ) ) {
 			$pmpro_error .= __( 'User creation failed.', 'pmpro-zapier' );
-		} elseif ( pmpro_hasMembershipLevel( null, $user_id ) ) {
-			$pmpro_error .= __( 'This user already has a membership level.', 'pmpro-zapier' );
+		} elseif ( pmpro_hasMembershipLevel( $level_id, $user_id ) ) {
+			$pmpro_error .= __( 'This user already has the membership level.', 'pmpro-zapier' );
 		}
 
 		// check the level


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add compatibility with PMPro Multiple Memberships Per User. Note that this does not include compatibility for purchasing multiple levels in a single checkout, only for managing users who have multiple levels.

Specific changes made include:
- Sending level data for level added on level change/after checkout
- Making sure to send the "old level status" for the cancelled level
- Allowing adding a level to a user who already has a different level on `add_member` action

Resolves #20 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.