### PR TITLE
Fixes a PHP error that occurs for non-admins

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -48,8 +48,9 @@ function pmproz_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . get_admin_url( null, 'admin.php?page=pmpro-zapier' ) . '">' . __( 'Settings', 'pmpro-zapier' ) . '</a>',
 		);
+        	$links = array_merge( $links, $new_links );
 	}
-	return array_merge( $links, $new_links );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . PMPRO_ZAPIER_BASENAME, 'pmproz_plugin_action_links' );
 


### PR DESCRIPTION
In some situations `$new_links` isn't declared in the `pmproz_plugin_action_links` function. This causes `null` to be passed as an argument to `array_merge` operation triggering a PHP error. This PR resolves this.