### PR TITLE
Add discount code data to orders

### DIFF
--- a/includes/class-pmpro-zapier.php
+++ b/includes/class-pmpro-zapier.php
@@ -82,6 +82,9 @@ class PMPro_Zapier {
 		// Get the saved order.
 		$order = new MemberOrder( $order->id );
 
+		// Add discount code data to order.
+		$order->getDiscountCode();
+
 		// Add some extra data to the result.
 		$data = array();
 
@@ -114,6 +117,9 @@ class PMPro_Zapier {
 
 		// Get the updated order.
 		$order = new MemberOrder( $order->id );
+	
+		// Add discount code data to order.
+		$order->getDiscountCode();
 
 		// Add some extra data to the result.
 		$data = array();
@@ -294,6 +300,7 @@ class PMPro_Zapier {
 		$prepared_order->user_id = $order->user_id;
 		$prepared_order->membership_id = $order->membership_id;
 		$prepared_order->billing = $order->billing;
+		$prepared_order->discount_code = $order->discount_code;
 		$prepared_order->subtotal = $order->subtotal;
 		$prepared_order->tax = $order->tax;
 		$prepared_order->total = $order->total;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Including discount code details in order data sent to Zapier

Resolves #53

### How to test the changes in this Pull Request:

1. Set up a webhook in Zapier.
2. Configure _New Order_, _Updated Order_, or _After Checkout_ triggers in PMPro Zapier.
3. Make a change on your site that initiates your trigger.
4. Check the trigger test data in Zapier. Observe that discount code details were passed. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
