### PR TITLE
Pass back user_id when add_member webhook is successful

### DIFF
--- a/includes/webhook-handler.php
+++ b/includes/webhook-handler.php
@@ -105,7 +105,12 @@ switch ( $action ) {
 
 		// add membership level
 		if ( empty( $pmpro_error ) && pmpro_changeMembershipLevel( $level_id, $user_id, 'zapier_changed' ) ) {
-			echo json_encode( array( 'status' => 'success' ) );
+			echo json_encode(
+				array(
+					'status' => 'success',
+					'user_id' => $user_id,
+				)
+			);
 			pmproz_webhook_log( __( 'changed level' , 'pmpro-zapier' ) );
 		} else {
 			echo json_encode(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Including discount code details in order data sent to Zapier

Resolves #52

### How to test the changes in this Pull Request:

1. Set up a zap that sends `add_member` data to PMPro.
2. Trigger Zap
3. Observe that User ID is present in _success_ response

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
