### PR TITLE
Include PMPro hook in Zapier data

### DIFF
--- a/includes/class-pmpro-zapier.php
+++ b/includes/class-pmpro-zapier.php
@@ -92,7 +92,9 @@ class PMPro_Zapier {
 
 		$data['order'] = self::prepare_order_for_request( $order );
     
-    	$data['date'] = date_i18n( get_option( 'date_format' ), $order->timestamp );
+		$data['date'] = date_i18n( get_option( 'date_format' ), $order->timestamp );
+
+		$data['trigger'] = 'pmpro_added_order';
     	
 		// filter the data before we send it to Zapier
 		$data = apply_filters('pmproz_added_order_data', $data, $order, $order->user_id );
@@ -127,6 +129,8 @@ class PMPro_Zapier {
 		$data['order'] = self::prepare_order_for_request( $order );
     
 	    $data['date'] = date_i18n( get_option( 'date_format' ), $order->timestamp );	   
+
+		$data['trigger'] = 'pmpro_updated_order';
     	
 	    // filter the data before we send it to Zapier
 		$data = apply_filters('pmproz_updated_order_data', $data, $order, $order->user_id );
@@ -190,6 +194,8 @@ class PMPro_Zapier {
 
 		$data['level'] = $level;
 
+		$data['trigger'] = 'pmpro_after_change_membership_level';
+
 		// filter the data before we send it to Zapier
 		$data = apply_filters('pmproz_after_change_membership_level_data', $data, $level_id, $user_id, $cancel_level);
 
@@ -244,6 +250,8 @@ class PMPro_Zapier {
 		} else if ( !empty( $_REQUEST['last_name'] ) ) {
 			$data['last_name'] = sanitize_text_field( $_REQUEST['last_name'] );
 		}
+
+		$data['trigger'] = 'pmpro_after_checkout';
 
 		$data = apply_filters( 'pmproz_after_checkout_data', $data, $user_id, $level, $order );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/convertkit-paid-memberships-pro/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/convertkit-paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Including the PMPro hook that triggered the Zap in Zapier data.
![image](https://github.com/user-attachments/assets/a132ec8c-0fbf-47c8-b34e-51ff27f38f41)

Resolves #45

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Now including the PMPro hook that triggered the Zap in Zapier data